### PR TITLE
Change `column_names` to parametric field

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -13,9 +13,9 @@ This structure helps to access elements that comply with the column access
 specification of Tables.jl.
 
 """
-struct ColumnTable{T}
+struct ColumnTable{T,V<:AbstractVector{Symbol}}
     table::T
-    column_names::Vector{Symbol}
+    column_names::V
     size::Tuple{Int,Int}
 end
 
@@ -26,9 +26,9 @@ This structure helps to access elements that comply with the row access
 specification of Tables.jl.
 
 """
-struct RowTable{T}
+struct RowTable{T,V<:AbstractVector{Symbol}}
     table::T
-    column_names::Vector{Symbol}
+    column_names::V
     size::Tuple{Int,Int}
 end
 


### PR DESCRIPTION
I figured I'd make a PR for #52 so that we have something more concrete to work with.

I started working on a small testable table type for testing something with non `Vector` names but then you'd also have to implement a new vector type that doesn't result in `Vector` after `collect(Symbol, Tables.columnnames(cols))` (e.g., like something from StaticArrays.jl). Before I went down that rabbit hole I wanted to see what you'd prefer.

At the very least I can confirm that these changes work for me locally.