### PR TITLE
Add option to overwrite in text output

### DIFF
--- a/src/backends/text/print.jl
+++ b/src/backends/text/print.jl
@@ -21,6 +21,7 @@ function _pt_text(io, pinfo;
                   highlighters::Union{Highlighter,Tuple} = (),
                   hlines::Union{Nothing,Symbol,AbstractVector} = nothing,
                   linebreaks::Bool = false,
+                  overwrite::Bool = false,
                   noheader::Bool = false,
                   nosubheader::Bool = false,
                   row_name_crayon::Crayon = Crayon(bold = true),
@@ -513,10 +514,21 @@ function _pt_text(io, pinfo;
         _draw_line!(screen, buf, tf.bottom_left_corner, tf.bottom_intersection,
                     tf.bottom_right_corner, tf.row, border_crayon, cols_width,
                     vlines)
-
+    
+    tablestring = String(take!(buf_io))
+                  
+    # Optional overwrite - Should be used the 2nd use onwards, assumes the previous table had the same number of rows
+    # ========================================================================== 
+    if overwrite  
+        for _ in 1:length(findall("\n",tablestring))
+            print("\e[1F") # move cursor up one row
+            print("\e[2K") # clear whole line
+        end
+    end
+    
     # Print the buffer
     # ==========================================================================
-    print(io, String(take!(buf_io)))
+    print(io, tablestring)
 
     return nothing
 end

--- a/src/backends/text/print.jl
+++ b/src/backends/text/print.jl
@@ -514,13 +514,11 @@ function _pt_text(io, pinfo;
         _draw_line!(screen, buf, tf.bottom_left_corner, tf.bottom_intersection,
                     tf.bottom_right_corner, tf.row, border_crayon, cols_width,
                     vlines)
-    
-    tablestring = String(take!(buf_io))
                   
     # Optional overwrite - Should be used the 2nd use onwards, assumes the previous table had the same number of rows
     # ========================================================================== 
     if overwrite  
-        for _ in 1:length(findall("\n",tablestring))
+        for _ in 1:screen.row - 1
             print("\e[1F") # move cursor up one row
             print("\e[2K") # clear whole line
         end
@@ -528,7 +526,7 @@ function _pt_text(io, pinfo;
     
     # Print the buffer
     # ==========================================================================
-    print(io, tablestring)
+    print(io, String(take!(buf_io)))
 
     return nothing
 end


### PR DESCRIPTION
This adds the option to overwrite the text-backend table, to allow for in-place terminal updates.

Caveats:
- `overwrite` should only be enabled on the 2nd print onwards (requires user control)
- The print function knows nothing about the previous print, use of this assumes the number of total printed rows hasn't changed.
- I wasn't sure how to add tests for this

```julia
using PrettyTables
let
    firstloop = true
    t = Timer(0, interval=1/2) # update speed, fps
    while true
        data = Any[  1    rand(Bool)     rand()     rand(UInt8) ;
                     2    rand(Bool)     rand()     rand(UInt8) ;
                     3    rand(Bool)     rand()     rand(UInt8) ;]
        pretty_table(data, overwrite=!firstloop)
        firstloop = false
        wait(t)
    end
end
```
```
┌────────┬────────┬─────────────────────┬────────┐
│ Col. 1 │ Col. 2 │              Col. 3 │ Col. 4 │
├────────┼────────┼─────────────────────┼────────┤
│      1 │  false │  0.4673248985284193 │    122 │
│      2 │   true │ 0.35361714109266695 │     48 │
│      3 │   true │  0.5376895960211221 │    116 │
└────────┴────────┴─────────────────────┴────────┘
```
(Table updates in-place at 2 FPS)