### PR TITLE
Adding rich output support for Markdown

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,6 +16,7 @@ Tables = "0.2,1.0"
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Parameters = "d96e819e-fc66-5662-9728-84c9c7592b0a"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"

--- a/src/PrettyTables.jl
+++ b/src/PrettyTables.jl
@@ -4,6 +4,7 @@ using Formatting
 using Parameters
 using Reexport
 using Tables
+using Markdown
 
 @reexport using Crayons
 

--- a/src/backends/html/print.jl
+++ b/src/backends/html/print.jl
@@ -88,7 +88,7 @@ function _pt_html(io, pinfo;
                 data_str_ij = replace(data_str_ij, "\n" => "<BR>")
             end
 
-            data_str_ij_esc = _str_escaped(data_str_ij)
+            data_str_ij_esc = data_ij isa Markdown.MD ? data_str_ij : _str_escaped(data_str_ij)
             data_str[j,i]   = data_str_ij_esc
         end
     end

--- a/src/backends/html/print.jl
+++ b/src/backends/html/print.jl
@@ -77,7 +77,7 @@ function _pt_html(io, pinfo;
             elseif data_ij == nothing
                 data_str_ij = "nothing"
             elseif data_ij isa Markdown.MD
-                data_str_ij = replace(repr(MIME("text/html"), data_ij),"\n</div>"=>"</div>")
+                data_str_ij = replace(sprint(show, "text/html", data_ij),"\n"=>"")
             else
                 data_str_ij = sprint(print, data_ij;
                                      context = :compact => compact_printing)

--- a/src/backends/html/print.jl
+++ b/src/backends/html/print.jl
@@ -76,6 +76,8 @@ function _pt_html(io, pinfo;
                 data_str_ij = "missing"
             elseif data_ij == nothing
                 data_str_ij = "nothing"
+            elseif data_ij isa Markdown.MD
+                data_str_ij = replace(repr(MIME("text/html"), data_ij),"\n</div>"=>"</div>")
             else
                 data_str_ij = sprint(print, data_ij;
                                      context = :compact => compact_printing)

--- a/src/backends/latex/print.jl
+++ b/src/backends/latex/print.jl
@@ -85,6 +85,8 @@ function _pt_latex(io, pinfo;
                 data_str_ij = "missing"
             elseif data_ij == nothing
                 data_str_ij = "nothing"
+            elseif data_ij isa Markdown.MD
+                data_str_ij = repr(MIME("text/latex"), data_ij)
             else
                 data_str_ij = sprint(print, data_ij;
                                      context = :compact => compact_printing)

--- a/src/backends/latex/print.jl
+++ b/src/backends/latex/print.jl
@@ -86,7 +86,7 @@ function _pt_latex(io, pinfo;
             elseif data_ij == nothing
                 data_str_ij = "nothing"
             elseif data_ij isa Markdown.MD
-                data_str_ij = repr(MIME("text/latex"), data_ij)
+                data_str_ij = replace(sprint(show, MIME("text/latex"), data_ij),"\n"=>"")
             else
                 data_str_ij = sprint(print, data_ij;
                                      context = :compact => compact_printing)

--- a/src/backends/text/print.jl
+++ b/src/backends/text/print.jl
@@ -270,12 +270,10 @@ function _pt_text(io, pinfo;
             elseif data_ij == nothing
                 data_str_ij = "nothing"
             elseif data_ij isa Markdown.MD
-                data_str_ij = sprint(print, data_ij;
-                                     context = :compact => compact_printing)
-                p = findfirst(c->c=='\n', data_str_ij)
-                if !isnothing(p)
-                    data_str_ij=data_str_ij[1:p-1]
-                end
+                r = repr(data_ij)
+                #len = min(something(findfirst(c->c=='\n', r), length(r) + 1) - 1, 50)
+                len = max(0, min(length(r), 50)-1)
+                data_str_ij = len < length(r) - 1 ? first(r, len)*"…" : first(r, len)
             else
                 data_str_ij = sprint(print, data_ij;
                                      context = :compact => compact_printing)

--- a/src/backends/text/print.jl
+++ b/src/backends/text/print.jl
@@ -269,6 +269,13 @@ function _pt_text(io, pinfo;
                 data_str_ij = "missing"
             elseif data_ij == nothing
                 data_str_ij = "nothing"
+            elseif data_ij isa Markdown.MD
+                data_str_ij = sprint(print, data_ij;
+                                     context = :compact => compact_printing)
+                p = findfirst(c->c=='\n', data_str_ij)
+                if !isnothing(p)
+                    data_str_ij=data_str_ij[1:p-1]
+                end
             else
                 data_str_ij = sprint(print, data_ij;
                                      context = :compact => compact_printing)

--- a/src/backends/text/print.jl
+++ b/src/backends/text/print.jl
@@ -271,8 +271,8 @@ function _pt_text(io, pinfo;
                 data_str_ij = "nothing"
             elseif data_ij isa Markdown.MD
                 r = repr(data_ij)
-                #len = min(something(findfirst(c->c=='\n', r), length(r) + 1) - 1, 50)
-                len = max(0, min(length(r), 50)-1)
+                #len = min(length(r, 1, something(findfirst(c->c=='\n', r), lastindex(r)+1)-1), 50)
+                len = max(0, min(length(r), 32)-1)
                 data_str_ij = len < length(r) - 1 ? first(r, len)*"…" : first(r, len)
             else
                 data_str_ij = sprint(print, data_ij;


### PR DESCRIPTION
I've added some simple code that permits rich output from Markdown cells in HTML and LaTeX.
I hope that you'll consider adding something like this to your fine package since it enables some really nice cell outputs - like URL links and images as well as rich text format.