### PR TITLE
Add predefined LaTeX format 'booktabs'

### DIFF
--- a/src/backends/latex/predefined_formats.jl
+++ b/src/backends/latex/predefined_formats.jl
@@ -6,7 +6,7 @@
 #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-export tf_latex_default, tf_latex_simple, tf_latex_modern
+export tf_latex_default, tf_latex_simple, tf_latex_modern, tf_latex_booktabs
 
 const tf_latex_default = LatexTableFormat()
 
@@ -32,4 +32,16 @@ const tf_latex_modern = LatexTableFormat(
     right_vline    = "!{\\vrule width 2pt}",
     header_envs    = ["textbf"],
     subheader_envs = ["texttt"]
+   )
+
+const tf_latex_booktabs = LatexTableFormat(
+    top_line       = "\\toprule",
+    header_line    = "\\midrule",
+    mid_line       = "\\midrule",
+    bottom_line    = "\\bottomrule",
+    left_vline     = "",
+    mid_vline      = "",
+    right_vline    = "",
+    header_envs    = ["textbf"],
+    subheader_envs = ["texttt"],
    )

--- a/test/latex_backend/default.jl
+++ b/test/latex_backend/default.jl
@@ -103,4 +103,29 @@ end
                           tf = tf_latex_modern)
 
     @test result == expected
+
+    # booktabs
+    # ==========================================================================
+
+    expected = """
+\\begin{table}
+  \\begin{tabular}{rrrr}
+    \\toprule
+    \\textbf{Col. 1} & \\textbf{Col. 2} & \\textbf{Col. 3} & \\textbf{Col. 4} \\\\\\midrule
+    1 & false & 1.0 & 1 \\\\\\midrule
+    2 & true & 2.0 & 2 \\\\\\midrule
+    3 & false & 3.0 & 3 \\\\\\midrule
+    4 & true & 4.0 & 4 \\\\\\midrule
+    5 & false & 5.0 & 5 \\\\\\midrule
+    6 & true & 6.0 & 6 \\\\\\bottomrule
+  \\end{tabular}
+\\end{table}
+"""
+
+    result = pretty_table(String, data,
+                          hlines = :all,
+                          vlines = :all,
+                          tf = tf_latex_booktabs)
+
+    @test result == expected
 end


### PR DESCRIPTION
This format works with the booktabs package, making the prettiest tables
in LaTeX. Uses its own horizontal rules, and intentionally ignores any
specification for vertical ditto (the booktabs documentation explains
why).