### PR TITLE
Qualify unexported Base function `need_full_hex`

### DIFF
--- a/src/backends/latex/string.jl
+++ b/src/backends/latex/string.jl
@@ -25,8 +25,8 @@ function _str_latex_escaped(io::IO, s::AbstractString, esc::String = "")
         elseif !isoverlong(c) && !ismalformed(c)
             isprint(c)         ? print(io, c) :
             c <= '\x7f'        ? print(io, "\\x", string(UInt32(c), base = 16, pad = 2)) :
-            c <= '\uffff'      ? print(io, "\\u", string(UInt32(c), base = 16, pad = need_full_hex(peek(a)) ? 4 : 2)) :
-                                 print(io, "\\U", string(UInt32(c), base = 16, pad = need_full_hex(peek(a)) ? 8 : 4))
+            c <= '\uffff'      ? print(io, "\\u", string(UInt32(c), base = 16, pad = Base.need_full_hex(peek(a)) ? 4 : 2)) :
+                                 print(io, "\\U", string(UInt32(c), base = 16, pad = Base.need_full_hex(peek(a)) ? 8 : 4))
         else # malformed or overlong
             u = bswap(reinterpret(UInt32, c))
             while true


### PR DESCRIPTION
The `Base` function `need_full_hex` appears to be unexported and needs to be qualified as `Base.need_full_hex`; this MWE triggers an error which is fixed by this PR:

```julia
using PrettyTables
header = [string('\U95a93')]
data = rand(1, 1)
backend = :latex
pretty_table(data, header; backend)

ERROR: UndefVarError: need_full_hex not defined
Stacktrace:
 [1] _str_latex_escaped(::Base.GenericIOBuffer{Array{UInt8,1}}, ::String, ::String) at /home/.julia/packages/PrettyTables/W16qB/src/backends/latex/string.jl:26
 [2] sprint(::Function, ::String, ::Vararg{String,N} where N; context::Nothing, sizehint::Int64) at ./strings/io.jl:105
 [3] _str_latex_escaped at /home/.julia/packages/PrettyTables/W16qB/src/backends/latex/string.jl:40 [inlined] (repeats 2 times)
 [4] #_parse_cell_latex#147 at /home/.julia/packages/PrettyTables/W16qB/src/backends/latex/cell_parse.jl:42 [inlined]
 [5] _pt_latex(::IOContext{Base.TTY}, ::PrettyTables.PrintInfo; tf::LatexTableFormat, body_hlines::Array{Int64,1}, cell_alignment::Dict{Tuple{Int64,Int64},Symbol}, highlighters::Tuple{}, hlines::Nothing, longtable_footer::Nothing, noheader::Bool, nosubheader::Bool, row_number_alignment::Symbol, table_type::Symbol, vlines::Nothing) at /home/.julia/packages/PrettyTables/W16qB/src/backends/latex/print.jl:101
 [6] _pt_latex at /home/.julia/packages/PrettyTables/W16qB/src/backends/latex/print.jl:24 [inlined]
 [7] _pt(::IOContext{Base.TTY}, ::Array{Float64,2}, ::Array{String,1}; alignment::Symbol, backend::Symbol, cell_alignment::Nothing, cell_first_line_only::Bool, compact_printing::Bool, filters_row::Nothing, filters_col::Nothing, formatters::Nothing, header_alignment::Symbol, header_cell_alignment::Nothing, renderer::Symbol, row_names::Nothing, row_name_alignment::Symbol, row_name_column_title::String, row_number_column_title::String, show_row_number::Bool, title::String, title_alignment::Symbol, kwargs::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}) at /home/.julia/packages/PrettyTables/W16qB/src/private.jl:426
 [8] #_pretty_table#67 at /home/.julia/packages/PrettyTables/W16qB/src/private.jl:356 [inlined]
 [9] #pretty_table#48 at /home/.julia/packages/PrettyTables/W16qB/src/print.jl:683 [inlined]
 [10] top-level scope at REPL[6]:1
```