### PR TITLE
Fix #105: compat bound on Reexport

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ version = "0.10.0"
 julia = "1"
 Crayons = "4.0"
 Formatting = "0.4"
-Reexport = "0.2"
+Reexport = "0.2,1.0"
 Tables = "0.2,1.0"
 
 [deps]


### PR DESCRIPTION
Following up on https://github.com/ronisbr/PrettyTables.jl/issues/105#issuecomment-754118014.
Let me know if you would like to retain compat with 0.2 also; I'm not too well-versed in managing compat bounds.