### PR TITLE
Very basic prototype of multicol with latex backend

### DIFF
--- a/src/backends/latex/print.jl
+++ b/src/backends/latex/print.jl
@@ -23,7 +23,8 @@ function _pt_latex(
     table_type::Union{Nothing, Symbol} = nothing,
     vlines::Union{Nothing, Symbol, AbstractVector} = nothing,
     wrap_table::Union{Nothing, Bool} = true,
-    wrap_table_environment::Union{Nothing, String} = nothing
+    wrap_table_environment::Union{Nothing, String} = nothing,
+    multicol::Union{Nothing, Tuple} = (1, 2)
 )
 
     # `r_io` must always be a reference to `IO`. Here, we unpack it. This is
@@ -258,8 +259,19 @@ function _pt_latex(
                 else
                     envs = subheader_envs
                 end
-
-                header_str_ij = _latex_envs(header_str[i,j], envs)
+                if !isnothing(multicol)
+                    mstart, mlen = multicol
+                    if mstart == j
+                        t = _latex_envs(header_str[i,j], envs)
+                        header_str_ij = "\\multicol{$mlen}{$t}"
+                    elseif j - mstart < mlen
+                        header_str_ij = ""
+                    else
+                        header_str_ij = _latex_envs(header_str[i,j], envs)
+                    end
+                else
+                    header_str_ij = _latex_envs(header_str[i,j], envs)
+                end
 
                 # Check the alignment of this cell.
                 alignment_ij::Symbol = header_alignment[jc]


### PR DESCRIPTION
@ronisbr 

As you know, multicolumn support in PrettyTables.jl is a feature I've wanted for a while. 

This PR is to add that support for the `:latex` backend. The reason to add multicolumn support to the latex backend, as opposed to html or plain text, is because of Latex's useful `\multicol` command. So we don't have to worry about whitespace at all. 

To be honest, my plan for this PR is to get a working prototype together, add tests, and then pass it off to you to for final organization into the total `pretty_table` pipeline. 

This is a minimal start for now. I will ping you when I have something you should actually review. 