### PR TITLE
Typo in docstring

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -170,7 +170,7 @@ filters. If this function returns `true` for `i`, then the i-th row (in case of
 Otherwise, it will be omitted.
 
 A set of filters can be passed inside of a tuple. Notice that, in this case,
--*all filters** for a specific row or column must be return `true` so that it
+**all filters** for a specific row or column must be return `true` so that it
 can be printed, *i.e* the set of filters has an `AND` logic.
 
 If the keyword is set to `nothing`, which is the default, then no filtering will


### PR DESCRIPTION
I was using the package and noticed a small typo in the help page. This is how is printing now on terminal:

![image](https://user-images.githubusercontent.com/43353831/136543979-7d2a0b12-aa24-4907-8071-e5eaaad46e84.png)
