### PR TITLE
Use first() function to get first row

### DIFF
--- a/src/private.jl
+++ b/src/private.jl
@@ -104,7 +104,7 @@ function _preprocess_Tables_row(
     table = Tables.rows(data)
 
     # We need to fetch the first row to get information about the columns.
-    row₁, ~ = iterate(table, 1)
+    row₁ = first(table)
 
     # Get the column names.
     names = collect(Symbol, Tables.columnnames(row₁))


### PR DESCRIPTION
The use of `iterate(table, 1)` to get the first row assumes that state is equal to row number. Using `first(table)` to get the first row should be a more robust solution (will error if the table is empty though, but it may not be necessary to check at this stage).