### PR TITLE
link from docs to repo

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,7 +8,8 @@ DocTestSetup = quote
 end
 ```
 
-This package has the purpose to print data in matrices in a human-readable
+The Julia package [PrettyTables.jl](https://github.com/ronisbr/PrettyTables.jl)
+has the purpose to print data in matrices in a human-readable
 format. It was inspired in the functionality provided by
 [ASCII Table Generator](https://ozh.github.io/ascii-tables/).
 


### PR DESCRIPTION
If one finds the docs first when searching for the package, it's nice to have a direct link to the repository.