### PR TITLE
switch to Printf stdlib from Formatting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,16 +7,15 @@ version = "2.2.6"
 
 [deps]
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
-Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
-Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 LaTeXStrings = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 StringManipulation = "892a3eda-7b42-436c-8928-eab12a02cf0e"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 Crayons = "4.0"
-Formatting = "0.4"
 LaTeXStrings = "1"
 OffsetArrays = "1"
 Reexport = "0.2, 1"

--- a/docs/src/man/formatters.md
+++ b/docs/src/man/formatters.md
@@ -107,12 +107,6 @@ julia> pretty_table(data; formatters = ft_printf("%5.3f", [1,3]))
 └────────┴──────────┴────────┘
 ```
 
-!!! note
-    Now, this formatter uses the function `sprintf1` from the package
-    [Formatting.jl](https://github.com/JuliaIO/Formatting.jl) that drastically
-    improved the performance compared to the case with the macro `@sprintf`.
-    Thanks to @RalphAS for the information!
-
 ```
 function ft_round(digits, [columns])
 ```

--- a/src/PrettyTables.jl
+++ b/src/PrettyTables.jl
@@ -1,10 +1,10 @@
 module PrettyTables
 
-using Formatting
 using Reexport
 using Tables
 using Markdown
 using StringManipulation
+using Printf
 
 @reexport using Crayons
 

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -145,3 +145,12 @@ macro pt(expr...)
 
     return Expr(:block, exprs...)
 end
+
+# Similar API to Formatting.jl, but using the Printf stdlib
+# (requires Julia 1.6+).
+function sprintf1(fmt::AbstractString, x)
+    return sprintf1(Printf.Format(fmt), x)
+end
+function sprintf1(fmt::Printf.Format, x)
+    Printf.format(fmt, x)
+end


### PR DESCRIPTION
closes https://github.com/ronisbr/PrettyTables.jl/issues/210

I noticed the original motivation for using Formatting.jl was performance, with a 100x5 table of floats being called out specifically as a benchmark. Since Julia 1.6, Printf has a fast dynamic formatter, and it seems to outperform Formatting.jl. With the benchmark

```julia
julia> using PrettyTables, BenchmarkTools

julia> data = Any[ f(a) for a = 1:100, f in (sind, cosd, tand, sind, sind)];

julia> @btime sprint(io -> pretty_table(io, data; formatters = ft_printf("%5.3f")));
```
on this branch I see
```julia
  667.000 μs (13377 allocations: 770.06 KiB)
```
whereas on master I see
```julia
  19.551 ms (32369 allocations: 1.58 MiB)
```

Additionally, all tests pass as-is, showing the compatibility of the approaches - I believe that is because PrettyTables is using just `sprintf1` which is meant to be like `@sprintf`. (As a quick check, I put in a `println("hi")` in the new `sprintf1` function to ensure it really is being called, and I could see it indeed is).