### PR TITLE
Enable easier dispatch on `pretty_table` for custom types

### DIFF
--- a/src/print.jl
+++ b/src/print.jl
@@ -699,14 +699,14 @@ compatible.
 """
 @inline function pretty_table(data; kwargs...)
     io = stdout isa Base.TTY ? IOContext(stdout, :limit => true) : stdout
-    _pretty_table(io, data; kwargs...)
+    pretty_table(io, data; kwargs...)
 end
 
 pretty_table(io::IO, data; kwargs...) = _pretty_table(io, data; kwargs...)
 
 function pretty_table(::Type{String}, data; color::Bool = false, kwargs...)
     io = IOContext(IOBuffer(), :color => color)
-    _pretty_table(io, data; kwargs...)
+    pretty_table(io, data; kwargs...)
     return String(take!(io.io))
 end
 


### PR DESCRIPTION
As a package author depending on `PrettyTables`, I want to define a method for two custom types. Method `A` transforms `a` into data that `PrettyTables` can use and calls `pretty_table`. Method `B` transforms `b` into an `A` and calls method `A`.

```julia
pretty_table(io::IO, a::A; kwargs...) = pretty_table(io, f(a); kwargs...)
pretty_table(io::IO, b::B; kwargs...) = pretty_table(io, A(b); kwargs...)
```

However, if I want `io` to default to `stdout`, I currently need to to write the following methods:

```julia
pretty_table(a::A; kwargs...) = pretty_table(stdout, f(a); kwargs...)
pretty_table(b::B; kwargs...) = pretty_table(stdout, A(b); kwargs...)
```

With this PR, those two methods are no longer necessary. This reduces code repetition and makes overloading `pretty_table` easier.