### PR TITLE
Redirect `stdout` to `devnull` during precompilation

### DIFF
--- a/src/precompilation.jl
+++ b/src/precompilation.jl
@@ -68,7 +68,7 @@ PrecompileTools.@setup_workload begin
     # We will redirect the `stdout` and `stdin` so that we can execute the pager and input
     # some commands without making visible changes to the user.
     old_stdout = Base.stdout
-    new_stdout = redirect_stdout()
+    new_stdout = redirect_stdout(devnull)
 
     # In HTML, we use `display` if we are rendering to `stdout`. However, even if we are
     # redirecting it, the text is still begin shown in the display. Thus, we create a buffer


### PR DESCRIPTION
Calling `redirect_stdout` without any arguments redirects the output to a newly created `Pipe`[^1] (which is mostly a wrapper around standard *nix pipes). Not reading data from this `Pipe` can result in precompilation to hang, e.g. in CI environments such as GitHub Actions (as was the case for me) or as reported here[^2].

This is due to a fundamental expectation that a (*nix) kernel has on pipes, as documented[^3], "write will block until sufficient data has been read from the pipe to allow the write to complete". For this reason never reading from `new_stdout` may cause the precompilation to hang. Explicitly redirecting to `devnull` circumvents this expectation and ensures precompilation succeeds.

I was able to verify the bug and the fix due to our (internal) CI systems getting stuck and trying with and without the fix (a couple of times to ensure the test was reliable/reproducible). Unfortunately, I don't have any publicly available logs to show as I couldn't get this reproduced on standard GitHub Actions runners. Likely because these always start with a fresh Julia depot and it appears that every time this becomes an issue some problem with the depot seems to trigger it.

Thanks to @vtjnash for pointing me in the right direction.

[^1]: https://github.com/JuliaLang/julia/blob/9233a16172139c06107b475480bfce098f10a8a6/base/stream.jl#L1259
[^2]: https://discourse.julialang.org/t/when-i-add-any-package-prettytables-will-get-stuck-here-and-cannot-be-executed-i-need-to-control-c-to-close-it
[^3]: https://man7.org/linux/man-pages/man7/pipe.7.html