### PR TITLE
Fix documentation: default is show_subheader=true?

### DIFF
--- a/docs/src/man/usage.md
+++ b/docs/src/man/usage.md
@@ -118,7 +118,7 @@ However, the following keywords are valid for all back ends:
     (**Default** = `false`)
 - `show_subheader::Bool`: If `true`, the sub-header will be printed, *i.e.*  the header will
     contain only one line. Notice that this option has no effect if `show_header = false`.
-    (**Default** = `false`)
+    (**Default** = `true`)
 - `title::AbstractString`: The title of the table. If it is empty, no title will be printed.
     (**Default** = "")
 - `title_alignment::Symbol`: Alignment of the title, which must be a symbol as explained in

--- a/docs/src/man/usage.md
+++ b/docs/src/man/usage.md
@@ -117,7 +117,7 @@ However, the following keywords are valid for all back ends:
 - `show_row_number::Bool`: If `true`, a new column will be printed showing the row number.
     (**Default** = `false`)
 - `show_subheader::Bool`: If `true`, the sub-header will be printed, *i.e.*  the header will
-    contain only one line. Notice that this option has no effect if `show_header = false`.
+    contain both the header and subheader. Notice that this option has no effect if `show_header = false`.
     (**Default** = `true`)
 - `title::AbstractString`: The title of the table. If it is empty, no title will be printed.
     (**Default** = "")

--- a/src/print.jl
+++ b/src/print.jl
@@ -108,7 +108,7 @@ following types are supported:
     (**Default** = `false`)
 - `show_subheader::Bool`: If `true`, the sub-header will be printed, *i.e.* the header will
     contain only one line. Notice that this option has no effect if `show_header = false`.
-    (**Default** = `false`)
+    (**Default** = `true`)
 - `title::AbstractString`: The title of the table. If it is empty, no title will be printed.
     (**Default** = "")
 - `title_alignment::Symbol`: Alignment of the title, which must be a symbol as

--- a/src/print.jl
+++ b/src/print.jl
@@ -107,7 +107,7 @@ following types are supported:
 - `show_row_number::Bool`: If `true`, a new column will be printed showing the row number.
     (**Default** = `false`)
 - `show_subheader::Bool`: If `true`, the sub-header will be printed, *i.e.* the header will
-    contain only one line. Notice that this option has no effect if `show_header = false`.
+    contain both the header and subheader. Notice that this option has no effect if `show_header = false`.
     (**Default** = `true`)
 - `title::AbstractString`: The title of the table. If it is empty, no title will be printed.
     (**Default** = "")


### PR DESCRIPTION
It looks like the default option for `pretty_table` is `show_subheader=true`. The docstring currently says the default is `false`.