### PR TITLE
Add compatibility with current version of DataFrames

### DIFF
--- a/src/backends/html/html_backend.jl
+++ b/src/backends/html/html_backend.jl
@@ -7,7 +7,7 @@
 function _html__print(
     pspec::PrintingSpec;
     allow_html_in_cells::Bool = false,
-    highlighters::Vector{HtmlHighlighter} = HtmlHighlighter[],
+    highlighters::Union{Vector{HtmlHighlighter}, NTuple{N, HtmlHighlighter} where N} = HtmlHighlighter[],
     is_stdout::Bool = false,
     line_breaks::Bool = false,
     maximum_column_width::String = "",

--- a/src/backends/text/text_backend.jl
+++ b/src/backends/text/text_backend.jl
@@ -13,7 +13,7 @@ const _DEFAULT_TEXT_HIGHLIGHTER = TextHighlighter[]
 function _text__print_table(
     pspec::PrintingSpec;
     alignment_anchor_fallback::Symbol = :l,
-    alignment_anchor_regex::Union{Vector{Regex}, Vector{Pair{Int, Vector{Regex}}}} = _DEFAULT_ALIGNMENT_ANCHOR_REGEX,
+    alignment_anchor_regex::Union{Vector{Regex}, Vector{Pair{Int, Vector{Regex}}}, Dict{Int, Vector{Regex}}} = _DEFAULT_ALIGNMENT_ANCHOR_REGEX,
     auto_wrap::Bool = false,
     column_label_width_based_on_first_line_only::Bool = false,
     display_size::NTuple{2, Int} = displaysize(pspec.context),
@@ -21,13 +21,14 @@ function _text__print_table(
     fit_table_in_display_horizontally::Bool = true,
     fit_table_in_display_vertically::Bool = true,
     fixed_data_column_widths::Union{Int, Vector{Int}} = 0,
-    highlighters::Vector{TextHighlighter} = _DEFAULT_TEXT_HIGHLIGHTER,
+    highlighters::Union{Vector{TextHighlighter}, NTuple{N, TextHighlighter} where N} = _DEFAULT_TEXT_HIGHLIGHTER,
     line_breaks::Bool = false,
     maximum_data_column_widths::Union{Int, Vector{Int}} = 0,
     overwrite_display::Bool = false,
     reserved_display_lines::Int = 0,
     style::TextTableStyle = TextTableStyle(),
     table_format::TextTableFormat = TextTableFormat(),
+    kwargs...
 )
     context    = pspec.context
     table_data = pspec.table_data
@@ -97,6 +98,7 @@ function _text__print_table(
         has_fixed_data_column_widths = true
     end
 
+    alignment_anchor_regex isa Dict && (alignment_anchor_regex = collect(alignment_anchor_regex))
     if alignment_anchor_regex isa Vector{Pair{Int, Vector{Regex}}}
         for (j, _) in alignment_anchor_regex
             (j <= 0) && throw(ArgumentError(

--- a/src/backends/text/types.jl
+++ b/src/backends/text/types.jl
@@ -290,3 +290,9 @@ struct TextHighlighter
 end
 
 _text__default_highlighter_fd(h::TextHighlighter, ::Any, ::Int, ::Int) = h._decoration
+
+HtmlDecoration(; kwargs...) = Pair{String, String}["$k" => "$v" for (k, v) in kwargs]
+
+# compat
+const Highlighter = TextHighlighter
+export Highlighter, HtmlDecoration

--- a/src/backends/text/types.jl
+++ b/src/backends/text/types.jl
@@ -291,8 +291,8 @@ end
 
 _text__default_highlighter_fd(h::TextHighlighter, ::Any, ::Int, ::Int) = h._decoration
 
-HtmlDecoration(; kwargs...) = Pair{String, String}["$k" => "$v" for (k, v) in kwargs]
+# for compatibility with current Version of DataFrames.jl
 
-# compat
 const Highlighter = TextHighlighter
+HtmlDecoration(; kwargs...) = Pair{String, String}["$k" => "$v" for (k, v) in kwargs]
 export Highlighter, HtmlDecoration

--- a/src/main.jl
+++ b/src/main.jl
@@ -80,7 +80,7 @@ function pretty_table(
 
     # == Other Configurations ==============================================================
 
-    formatters::Union{Nothing, Vector{T} where T <: Any} = nothing,
+    formatters::Union{Nothing, Vector, Tuple} = nothing,
     maximum_number_of_columns::Int = -1,
     maximum_number_of_rows::Int = -1,
     merge_column_label_cells::Union{Symbol, Vector{MergeCells}} = :auto,
@@ -137,7 +137,7 @@ function pretty_table(
         # == Other Configurations ==========================================================
 
         cell_alignment,
-        formatters,
+        formatters isa Tuple ? collect(formatters) : formatters,
         maximum_number_of_columns,
         maximum_number_of_rows,
         merge_column_label_cells,


### PR DESCRIPTION
Currently v3 of PrettyTables cannot be tested together with the latest version of DataFrames.
In this PR I have added some modifications that remedy this situation. This fix is not perfect, some arguments in the text backend get lost, because I couldn't find out how to treat them properly.
I am aware that this is compromising the new type system, but maybe it's something that can be applied for the first version of v3 for a transition period, as this will certainly affect more packages than DataFrames.
@ronisbr Happy to hear what you think.