### PR TITLE
Prevent blinking on Windows with overwrite_display

### DIFF
--- a/src/backends/text/text_backend.jl
+++ b/src/backends/text/text_backend.jl
@@ -1397,10 +1397,10 @@ function _text__print_table(
 
     if overwrite_display
         num_new_lines = max(count(==('\n'), output_str), 0)
-        print(context, "\e[1F\e[2K"^num_new_lines)
+        print(context, "\e[1F\e[2K"^num_new_lines * output_str)
+    else
+        print(context, output_str)
     end
-
-    print(context, output_str)
 
     return nothing
 end


### PR DESCRIPTION
Fixes #265

When overwrite_display keyword is used, output control characters  and table with a single print statement, rather than two separate print statements. The former seems to avoid blinking between successive displays.