### PR TITLE
make `0` autosize column width as documented

### DIFF
--- a/src/backends/text/text_backend.jl
+++ b/src/backends/text/text_backend.jl
@@ -166,7 +166,7 @@ function _text__print_table(
             mc = 1
 
             for j in eachindex(fixed_data_column_widths)
-                aux += fixed_data_column_widths[j] < 0 ? 5 : fixed_data_column_widths[j]
+                aux += fixed_data_column_widths[j] <= 0 ? 5 : fixed_data_column_widths[j]
                 aux > display.size[2] && break
                 mc += 1
             end

--- a/test/backends/text/line_breaks.jl
+++ b/test/backends/text/line_breaks.jl
@@ -153,7 +153,7 @@ end
         table;
         auto_wrap                = true,
         column_labels            = column_labels,
-        fixed_data_column_widths = [-1, 30],
+        fixed_data_column_widths = [0, 30],
         line_breaks              = true,
         table_format             = TextTableFormat(; @text__all_horizontal_lines)
     )


### PR DESCRIPTION
Currently within the text backend, providing a value of `0` to some of the entries in `fixed_data_column_widths` does not make the column width size based on the largest cell contradicting the [documentation]( https://ronisbr.github.io/PrettyTables.jl/stable/man/text/text_backend/#Keywords).

This simple PR just update the code to reflects the behavior in the documentation (and modifies a single test to also test providing  a 0 instead of a negative number).

I considered updating the documentation but this change would seem more consistent with the behavior when a single `Int` is provided which actually autosizes for `0`