### PR TITLE
fix: use literal reset escape sequence to avoid precompilation issues

### DIFF
--- a/src/backends/text/types.jl
+++ b/src/backends/text/types.jl
@@ -101,8 +101,9 @@ const _TEXT__DEFAULT             = crayon"default"
 const _TEXT__EMPTY_CRAYON        = crayon""
 const _TEXT__RESET               = crayon"reset"
 
-# Convert the reset crayon to string to reduce allocations.
-const _TEXT__STRING_RESET = string(_TEXT__RESET)
+# The reset escape sequence. We use the literal string instead of `string(_TEXT__RESET)`
+# because Crayons may produce an empty string when colors are disabled at precompilation time.
+const _TEXT__STRING_RESET = "\e[0m"
 
 """
     struct TextTableFormat

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,17 @@
 using Test
 using PrettyTables
 
+using Crayons
 using LaTeXStrings
 using Markdown
 using OffsetArrays
 using StyledStrings
 using Tables
+
+# Force color output for tests to ensure ANSI escape codes are generated.
+# This is needed because Crayons.jl may disable colors during precompilation or
+# in non-TTY environments like CI.
+Crayons.force_color(true)
 
 ############################################################################################
 #                                   Types and Structures                                   #


### PR DESCRIPTION
When Crayons.jl is precompiled with colors disabled (e.g., in a non-TTY environment), `string(crayon"reset")` produces an empty string. This caused the reset escape sequence to not be emitted after styled cells, leading to color bleeding into subsequent cells.

Example that previously didn't work but now works:

```julia
using PrettyTables

data = [1 2; 3 4]
hl = TextHighlighter((d, i, j) -> j == 1, crayon"green")
result = pretty_table(String, data; color = true, highlighters = [hl])

# Before fix - green color from column 1 bleeds into column 2:
# "│ \e[32m  1   │   2 │"  (missing \e[0m after "1")
#
# After fix - reset code properly terminates the color:
# "│ \e[32m  1 \e[0m│   2 │"
```

Fix by using the literal escape sequence "\e[0m" instead of `string(_TEXT__RESET)` for `_TEXT__STRING_RESET`.

Also add `Crayons.force_color(true)` to tests to ensure consistent behavior across different environments.