### PR TITLE
Allow highlighters to be applied cumulatively.

### DIFF
--- a/docs/src/man/html/html_backend.md
+++ b/docs/src/man/html/html_backend.md
@@ -72,8 +72,7 @@ whereas the second lets the user select the desired decoration by specifying the
 
 !!! note
 
-    If multiple highlighters are valid for the element `(i, j)`, the applied style will be
-    equal to the first match considering the order in the vector `highlighters`.
+    If multiple highlighters are valid for the element `(i, j)`, they will be applied applied progressively.
 
 !!! note
 

--- a/src/backends/html/html_backend.jl
+++ b/src/backends/html/html_backend.jl
@@ -397,14 +397,15 @@ function _html__print(
             # If we are in a data cell, we must check for highlighters.
             if action == :data
                 orig_data = _get_data(table_data.data)
-
                 if !isnothing(highlighters)
+                    all_highs = Dict{String,String}()
                     for h in highlighters
                         if h.f(orig_data, ps.i, ps.j)
-                            append!(vstyle, h.fd(h, orig_data, ps.i, ps.j))
-                            break
+                            highs = h.fd(h, orig_data, ps.i, ps.j)
+                            merge!( all_highs, Dict( highs ))
                         end
                     end
+                    append!(vstyle, collect(all_highs))
                 end
             end
 

--- a/test/backends/html/highlighters.jl
+++ b/test/backends/html/highlighters.jl
@@ -39,8 +39,8 @@
         matrix;
         backend = :html,
         highlighters = [
-            HtmlHighlighter((data, i, j) -> data[i, j] % 2 == 0, "color" => "red"),
             HtmlHighlighter((data, i, j) -> data[i, j] % 2 == 0, ["color" => "blue"]),
+            HtmlHighlighter((data, i, j) -> data[i, j] % 2 == 0, "color" => "red"),
             HtmlHighlighter((data, i, j) -> data[i, j] % 2 != 0, ["font-weight" => "bold"], "color" => "green")
         ]
     )
@@ -52,8 +52,8 @@
         matrix;
         backend = :html,
         highlighters = [
-            HtmlHighlighter((data, i, j) -> data[i, j] % 2 == 0, (_, _, _, _) -> ["color" => "red"]),
             HtmlHighlighter((data, i, j) -> data[i, j] % 2 == 0, ["color" => "blue"]),
+            HtmlHighlighter((data, i, j) -> data[i, j] % 2 == 0, (_, _, _, _) -> ["color" => "red"]),
             HtmlHighlighter((data, i, j) -> data[i, j] % 2 != 0, ["font-weight" => "bold"], "color" => "green")
         ]
     )


### PR DESCRIPTION
Hi,

here is a small patch that allows the HTML highlighters to be applied cumulatively, rather than using just the 1st match. (For a slightly tricky table I was working on the simplest thing to do seemed to be to apply formatting by matching in stages). This is for the HTML backend only but if you're OK with this I'm happy to do something similar to the other backends.

Many thanks for your work on PrettyTables - I've found it very useful and easy to use.

Graham